### PR TITLE
Fix DBS input from file

### DIFF
--- a/R/mut.to.sigs.input.R
+++ b/R/mut.to.sigs.input.R
@@ -54,10 +54,12 @@ mut.to.sigs.input = function(mut.ref, sample.id = 'Sample', chr = 'chr', pos = '
   
   # don't need trinucleotide context if looking for DBS
   if(sig.type == 'DBS'){
+    mut[,ref] <- as.character(mut[,ref])
+    mut[,alt] <- as.character(mut[,alt])
     mut <- mut[which(nchar(mut[, ref]) ==2 & nchar(mut[,alt]) == 2),]
     mut$dbs <- paste(mut[,ref], mut[,alt], sep = '>') 
     mut$dbs_condensed <- dbs_possible$dbs_condensed[match(mut$dbs, dbs_possible$dbs)]
-    final.df <- as.data.frame.matrix(table(mut$Sample, factor(mut$dbs_condensed, levels = unique(dbs_possible$dbs_condensed))), stringsAsFactors = FALSE)
+    final.df <- as.data.frame.matrix(table(mut[,sample.id], factor(mut$dbs_condensed, levels = unique(dbs_possible$dbs_condensed))), stringsAsFactors = FALSE)
   }
   
   # And now look at SBS


### PR DESCRIPTION
Fixes two potential bugs when loading mutations in double-base substitution mode from a table:

1. ref and alt columns can be loaded as factors instead of character vectors, which causes nchar() to fail.
2. DBS loading mode requires the sample ID column to be named "Sample", rather than using the sample.id argument

May need more testing before merging, but seems to work well with our data.