### PR TITLE
Update whichSignatures.R

### DIFF
--- a/R/whichSignatures.R
+++ b/R/whichSignatures.R
@@ -92,7 +92,7 @@ whichSignatures = function(tumor.ref = NA,
     stop(paste(sample.id, " not found in rownames of tumor.ref", sep = ''))
   }
   tumor <- subset(tumor, rownames(tumor) == sample.id)
-  if(round(rowSums(tumor), digits = 1) != 1){
+  if(round(rowSums(tumor), digits = 0) != 1){
     stop(paste('Sample: ', sample.id, ' is not normalized\n', 'Consider using "contexts.needed = TRUE"', sep = ' '))
   }
   


### PR DESCRIPTION
[SP107141_sub_data.txt](https://github.com/raerose01/deconstructSigs/files/6201754/SP107141_sub_data.txt)
For some cases, such as the SP107141 sample mutation data I've uploaded,  after "default" normalization `norm.mut.counts           <- mut.counts/rowSums(mut.counts)`, the code `round(rowSums(tumor), digits = 1) != 1` will be TRUE.