### PR TITLE
Switch df[,col] to df[[col]] to get column vectors

### DIFF
--- a/R/internal.scripts.R
+++ b/R/internal.scripts.R
@@ -17,7 +17,7 @@ getError = function(tumor, signatures, w){
   error = tumor - product
   penalized.error = error
   neg = which(penalized.error < 0)
-  penalized.error[,neg] = 1*penalized.error[,neg]
+  penalized.error[[neg]] = 1*penalized.error[[neg]]
   tot = sum(penalized.error * penalized.error)
   return(tot)
 } 

--- a/R/mut.to.sigs.input.R
+++ b/R/mut.to.sigs.input.R
@@ -54,40 +54,40 @@ mut.to.sigs.input = function(mut.ref, sample.id = 'Sample', chr = 'chr', pos = '
   
   # don't need trinucleotide context if looking for DBS
   if(sig.type == 'DBS'){
-    mut[,ref] <- as.character(mut[,ref])
-    mut[,alt] <- as.character(mut[,alt])
-    mut <- mut[which(nchar(mut[, ref]) ==2 & nchar(mut[,alt]) == 2),]
-    mut$dbs <- paste(mut[,ref], mut[,alt], sep = '>') 
+    mut[[ref]] <- as.character(mut[[ref]])
+    mut[[alt]] <- as.character(mut[[alt]])
+    mut <- mut[which(nchar(mut[[ref]]) ==2 & nchar(mut[[alt]]) == 2),]
+    mut$dbs <- paste(mut[[ref]], mut[[alt]], sep = '>') 
     mut$dbs_condensed <- dbs_possible$dbs_condensed[match(mut$dbs, dbs_possible$dbs)]
     final.df <- as.data.frame.matrix(table(mut[,sample.id], factor(mut$dbs_condensed, levels = unique(dbs_possible$dbs_condensed))), stringsAsFactors = FALSE)
   }
   
   # And now look at SBS
-  #mut.lengths <- with(mut, nchar(as.character(mut[,ref])))
+  #mut.lengths <- with(mut, nchar(as.character(mut[[ref]])))
   #mut.lengths <- with(mut, nchar(as.character(ref)))
   #mut <- mut[which(mut.lengths == 1),]
-  #mut$mut.lengths <- nchar(as.character(mut[, ref]))
+  #mut$mut.lengths <- nchar(as.character(mut[[ref]]))
   if(sig.type == 'SBS'){
-    mut <- mut[which(mut[, ref] %in% c('A', 'T', 'C', 'G') & mut[, alt] %in% c('A', 'T', 'C', 'G')),]
+    mut <- mut[which(mut[[ref]] %in% c('A', 'T', 'C', 'G') & mut[[alt]] %in% c('A', 'T', 'C', 'G')),]
   
     # Fix the chromosome names (in case they come from Ensembl instead of UCSC)
-    mut[, chr] <- factor(mut[, chr])
-    levels(mut[, chr]) <- sub("^([0-9XY])", "chr\\1", levels(mut[, chr]))
-    levels(mut[, chr]) <- sub("^MT", "chrM", levels(mut[, chr]))
-    levels(mut[, chr]) <- sub("^(GL[0-9]+).[0-9]", "chrUn_\\L\\1", levels(mut[, chr]), perl = T)
+    mut[[chr]] <- factor(mut[[chr]])
+    levels(mut[[chr]]) <- sub("^([0-9XY])", "chr\\1", levels(mut[[chr]]))
+    levels(mut[[chr]]) <- sub("^MT", "chrM", levels(mut[[chr]]))
+    levels(mut[[chr]]) <- sub("^(GL[0-9]+).[0-9]", "chrUn_\\L\\1", levels(mut[[chr]]), perl = T)
   
     # Check the genome version the user wants to use
     # If set to default, carry on happily
     if(is.null(bsg)){
       # Remove any entry in chromosomes that do not exist in the BSgenome.Hsapiens.UCSC.hg19::Hsapiens object    
-      unknown.regions <- levels(mut[, chr])[which(!(levels(mut[, chr]) %in% GenomeInfoDb::seqnames(BSgenome.Hsapiens.UCSC.hg19::Hsapiens)))]
+      unknown.regions <- levels(mut[[chr]])[which(!(levels(mut[[chr]]) %in% GenomeInfoDb::seqnames(BSgenome.Hsapiens.UCSC.hg19::Hsapiens)))]
       if (length(unknown.regions) > 0) {
         unknown.regions <- paste(unknown.regions, collapse = ',\ ')
         warning(paste('Check chr names -- not all match BSgenome.Hsapiens.UCSC.hg19::Hsapiens object:\n', unknown.regions, sep = ' '))      
-        mut <- mut[mut[, chr] %in% GenomeInfoDb::seqnames(BSgenome.Hsapiens.UCSC.hg19::Hsapiens), ]
+        mut <- mut[mut[[chr]] %in% GenomeInfoDb::seqnames(BSgenome.Hsapiens.UCSC.hg19::Hsapiens), ]
       }
       # Add in context
-      mut$context = BSgenome::getSeq(BSgenome.Hsapiens.UCSC.hg19::Hsapiens, mut[,chr], mut[,pos]-1, mut[,pos]+1, as.character = T)
+      mut$context = BSgenome::getSeq(BSgenome.Hsapiens.UCSC.hg19::Hsapiens, mut[[chr]], mut[[pos]]-1, mut[[pos]]+1, as.character = T)
     }
     
     # If set to another build, use that one 
@@ -97,21 +97,21 @@ mut.to.sigs.input = function(mut.ref, sample.id = 'Sample', chr = 'chr', pos = '
         stop('The bsg parameter needs to either be set to default or a BSgenome object.')
       }
       # Remove any entry in chromosomes that do not exist in the BSgenome.Hsapiens.UCSC.hgX::Hsapiens object
-      unknown.regions <- levels(mut[, chr])[which(!(levels(mut[, chr]) %in% GenomeInfoDb::seqnames(bsg)))]
+      unknown.regions <- levels(mut[[chr]])[which(!(levels(mut[[chr]]) %in% GenomeInfoDb::seqnames(bsg)))]
       if (length(unknown.regions) > 0) {
         unknown.regions <- paste(unknown.regions, collapse = ',\ ')
         warning(paste('Check chr names -- not all match',attr(bsg, which = 'pkgname'),'object:\n', unknown.regions, sep = ' '))
-        mut <- mut[mut[, chr] %in% GenomeInfoDb::seqnames(bsg), ]
+        mut <- mut[mut[[chr]] %in% GenomeInfoDb::seqnames(bsg), ]
       }
       # Add in context
-      mut$context = BSgenome::getSeq(bsg, mut[,chr], mut[,pos]-1, mut[,pos]+1, as.character = T) 
+      mut$context = BSgenome::getSeq(bsg, mut[[chr]], mut[[pos]]-1, mut[[pos]]+1, as.character = T) 
     }
    
-    mut$mutcat = paste(mut[,ref], ">", mut[,alt], sep = "")
+    mut$mutcat = paste(mut[[ref]], ">", mut[[alt]], sep = "")
     
-    if(any(substr(mut[,ref], 1, 1) != substr(mut[,'context'], 2, 2))){
-      bad = mut[ which(substr(mut[,ref], 1, 1) != substr(mut[,'context'], 2, 2)), ]
-      bad = paste(bad[,sample.id], bad[,chr], bad[,pos], bad[,ref], bad[,alt], sep = ':')
+    if(any(substr(mut[[ref]], 1, 1) != substr(mut[,'context'], 2, 2))){
+      bad = mut[ which(substr(mut[[ref]], 1, 1) != substr(mut[,'context'], 2, 2)), ]
+      bad = paste(bad[,sample.id], bad[[chr]], bad[[pos]], bad[[ref]], bad[[alt]], sep = ':')
       bad = paste(bad, collapse = ',\ ')
       warning(paste('Check ref bases -- not all match context:\n ', bad, sep = ' '))
     }

--- a/R/vcf.to.sigs.input.R
+++ b/R/vcf.to.sigs.input.R
@@ -41,7 +41,7 @@ vcf.to.sigs.input <- function(vcf, bsg = NULL) {
 
   mut <- data.frame()
   for (sample in colnames(gt)) {
-    a1 <- sub("[/|].+", "", gt[, sample])
+    a1 <- sub("[/|].+", "", gt[[sample]])
     alt1 <- which(ref != a1)
     if (length(alt1) > 0) {
       mut <- rbind(mut, data.frame(sample = sample,
@@ -50,7 +50,7 @@ vcf.to.sigs.input <- function(vcf, bsg = NULL) {
                                    ref = ref[alt1],
                                    alt = a1[alt1]))
     }  
-    a2 <- sub(".+[/|]", "", gt[, sample])
+    a2 <- sub(".+[/|]", "", gt[[sample]])
     alt2 <- which(ref != a2 & a1 != a2)
     if (length(alt2) > 0) {
       mut <- rbind(mut, data.frame(sample = sample,


### PR DESCRIPTION
The package previously used the format `df[, col]` to extract a column as a vector I changed these to be `df[[col]]` which is compliant with more recent versions of R where `df[, col]` returns a data.frame with one column rather than a vector. This return type leads to expressions such as `mut[, ref] %in% c('A', 'T', 'C', 'G')` failing as it is not checking the values of `ref`, but rather the data.frame names for matching.